### PR TITLE
Corretti alcuni refusi

### DIFF
--- a/processing_tests.html
+++ b/processing_tests.html
@@ -84,25 +84,25 @@
           <div class="col-sm-12 col-md-8">
             <ul class="page-nav">
               <li>
-                <a href="#about">Obiettivi</a>
+                <a href="http://qgis.it/#about">Obiettivi</a>
               </li>
               <li>
-                <a href="#meetings">Partecipa</a>
+                <a href="http://qgis.it/#meetings">Partecipa</a>
               </li>
               <li>
-                <a href="#cooperate">Collabora</a>
+                <a href="http://qgis.it/#cooperate">Collabora</a>
               </li>
               <li>
-                <a href="#support">Sostieni</a>
+                <a href="http://qgis.it/#support">Sostieni</a>
               </li>
               <li>
                 <a href="http://qgis.it/processing_tests.html">Processing Test</a>
               </li>
               <li>
-                <a href="#translation">Traduzioni</a>
+                <a href="http://qgis.it/#translation">Traduzioni</a>
               </li>
               <li>
-                <a href="#contact">Contatti</a>
+                <a href="http://qgis.it/#contact">Contatti</a>
               </li>
             </ul>
           </div>
@@ -248,19 +248,19 @@
           <img src="images/processing_test/densify_test.png" width=40% height=40%>
           </div>
         </p>
-        <p class="lead">E&egrave; quindi <strong>fondamentale</strong> cercare <strong>prima</strong> gli algoritmi sprovvisti di test per evitare di creare dei doppioni.
+        <p class="lead">&Egrave; quindi <strong>fondamentale</strong> cercare <strong>prima</strong> gli algoritmi sprovvisti di test per evitare di creare dei doppioni.
         </p>
 
 
         <h4 class="featurette-heading-minus">6. Lanciare l'algoritmo e verificare che il risultato sia corretto</h4>
         <p class="lead">
-          Tutta questa parte si svolte <strong>dentro</strong> QGIS.
+          Tutta questa parte si svolge <strong>dentro</strong> QGIS.
         </p>
         <p class="lead">
           L'architettura dei test &egrave; accompagnata da alcuni dati predefiniti da utilizzare. Se i dati forniti non dovessero essere adatti si possono tranquillamente aggiungere altri dati nel repository.
         </p>
         <p class="lead">
-          Questi dati (ed eventualmente anche dai creati ad hoc) sono nella cartella: <code>QGIS/QGIS/python/plugins/processing/tests/testdata/custom</code> del repository locale di QGIS.
+          Questi dati (ed eventualmente anche dati creati ad hoc) sono nella cartella: <code>QGIS/QGIS/python/plugins/processing/tests/testdata/custom</code> del repository locale di QGIS.
         </p>
         <p class="lead">
           Affinch&egrave; i test funzionino correttamente &egrave; <strong>fondamentale</strong> usare <strong>solamente</strong> dati presenti in questa cartella.
@@ -378,7 +378,7 @@
           Quando siete sicuri cliccate su <code>Create Pull Request</code>. Verrete reindirizzati all'elenco di tutte le Pull Request di QGIS dove potete vedere l'avanzamento della compilazione remota di QGIS e verificare che il procedimento sia stato effettuato correttamente:
         </p>
         <p class="lead">
-          Quando gli sviluppatori lo riterranno opportuno uniranno (tecnicamente faranno un <em>merge</em>) della vostra Pull Request e qull'algoritmo di QGIS sar&agrave; cosi blindato.
+          Quando gli sviluppatori lo riterranno opportuno uniranno la vostra Pull Request (tecnicamente faranno un <em>merge</em>) e quell'algoritmo di QGIS sar&agrave; cosi blindato.
         </p>
 
 

--- a/traduzione.html
+++ b/traduzione.html
@@ -96,6 +96,9 @@
                 <a href="http://qgis.it#support">Sostieni</a>
               </li>
               <li>
+                <a href="http://qgis.it/processing_tests.html">Processing Test</a>
+              </li>
+              <li>
                 <a href="http://qgis.it#translation">Traduzioni</a>
               </li>
               <li>


### PR DESCRIPTION
- nella pagina processing_tests.html i link di navigazione, "Obiettivi", "Partecipa", "Collabora", ..., non rimandano ai relativi bookmark della home page: i link sono erroneamente del tipo `<a href="#about">Obiettivi</a>` invece che `<a href="http://qgis.it/#about">Obiettivi</a>`
- refusi nella pagina "Processing Test":
 - "**Eè** quindi", paragrafo 5, ultimo capoverso
 - "si **svolte** dentro QGIS", paragrafo 6, primo capoverso
 - "anche **dai** creati", paragrafo 6, terzo capoverso
 - " uniranno (tecnicamente faranno un merge) **della** vostra Pull Request e **qull'algoritmo** di QGIS", paragrafo 9, ultimo capoverso
- nella pagina traduzione.html manca il link a "Processing Test".